### PR TITLE
Fix the issue of spaces in library version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,8 @@
-
-nltk == 3.6.2
-
-
-openai == 0.11.0
-
-pandas == 1.3.0
-
-python_Levenshtein == 0.12.2
-scikit_learn == 0.24.2
-sentence_transformers == 2.1.0
-spacy == 3.1.1
-torch == 1.9.0
+nltk==3.6.2
+openai==0.11.0
+pandas==1.3.0
+python_Levenshtein==0.12.2
+scikit_learn==0.24.2
+sentence_transformers==2.1.0
+spacy==3.1.1
+torch==1.9.0


### PR DESCRIPTION
## Issue in `requirements.txt`
Failed to install requirements as there are extra spaces between library name and version.